### PR TITLE
Fix python2 python3 round compatiblity

### DIFF
--- a/cassandra_sigv4/auth.py
+++ b/cassandra_sigv4/auth.py
@@ -93,7 +93,7 @@ def _extract_nonce(challenge):
 
 def _format_timestamp(date_time):
     return "{0}.{1:03d}Z".format(date_time.strftime(_SIGV4_TIMESTAMP_FORMAT),
-                                 round(date_time.microsecond / 1000))
+                                 int(round(date_time.microsecond / 1000)))
 
 
 def _format_datestamp(date_time):


### PR DESCRIPTION
In python2 round will return a float. need to cast it with an integer so that the string format d will not throw a value error.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
